### PR TITLE
Support --data option

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,6 +103,9 @@ var main = function() {
       if(!process.stdin.isTTY) {
         input = yield readStdin();
       }
+      if(!input) {
+        input = options.data || options.d;
+      }
 
       if(!maybeUrl || (maybeUrl && maybeUrl == 'help') || options.help || options.h) {
         console.log('Usage: aws-es-curl [options] <url>');
@@ -111,6 +114,7 @@ var main = function() {
         console.log("\t-X, --method \tHTTP method \t(Default: GET)");
         console.log("\t--profile \tAWS profile \t(Default: default)");
         console.log("\t--region \tAWS region \t(Default: eu-west-1)");
+        console.log("\t-d, --data \tSends the specified data in a POST request");
         process.exit(1);
       }
 


### PR DESCRIPTION
I added `--data` or `-d` option. 
And I added it to `--help`.

## examples
```sh
bin/aws-es-curl --profile dev_guest --region ap-northeast-1 --method POST https://xxx.ap-northeast-1.es.amazonaws.com/xxx/_search\?pretty --data '{"sort":[{"_id":"desc"}]}'
```
