### PR TITLE
Utilize AWS_DEFAULT_REGION

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,7 +95,7 @@ var main = function() {
   co(function*(){
       var maybeUrl = options._[0];
       var method = options.X || options.method || 'GET';
-      var region = options.region || process.env.AWS_REGION || 'eu-west-1';
+      var region = options.region || process.env.AWS_DEFAULT_REGION || process.env.AWS_REGION || 'eu-west-1';
 
       yield getCredentials();
 


### PR DESCRIPTION
Per https://docs.aws.amazon.com/cli/latest/userguide/cli-environment.html, the proper environment variable for 'region' is AWS_DEFAULT_REGION. This change prefers AWS_DEFAULT_REGION to AWS_REGION, but leaves the latter in for historical purposes.