### PR TITLE
Resolve credentials before we try to use them, refs #8

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,6 +34,7 @@ var getCredentials = function*() {
       // see also 'The Shared Credentials File' http://docs.aws.amazon.com/cli/latest/topic/config-vars.html
       filename: process.env.AWS_SHARED_CREDENTIALS_FILE
    });
+   return credentials.getPromise();
 }
 
 var readStdin = function() {


### PR DESCRIPTION
Fix an issue where you couldn't use a profile that assumed a role. By
returning and resolving getPromise(), AWS.SharedIniFileCredentials will
obtain AWS.TemporaryCredentials and update itself accordingly.