### PR TITLE
feat: Add support for the kbn-xsrf header

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,6 +72,7 @@ var execute = function(endpoint, region, path, method, body) {
 
     req.headers['presigned-expires'] = false;
     req.headers['content-type'] = 'application/json';
+    req.headers['kbn-xsrf'] = true;
     req.headers.Host = endpoint.host;
 
     var signer = new AWS.Signers.V4(req, 'es');


### PR DESCRIPTION
This should be ignored by ElasticSearch but is required when making Kibana API calls (https://www.elastic.co/guide/en/kibana/7.15/api.html#api-request-headers).

Adding this will allow to both target ElasticSearch and Kibana API using aws-sigv4 signed requests.

Similar to that PR that added the support to aws-es-proxy: https://github.com/abutaha/aws-es-proxy/pull/72